### PR TITLE
Fix: Cart Total on item remove

### DIFF
--- a/src/pages/cart/Cart.jsx
+++ b/src/pages/cart/Cart.jsx
@@ -17,10 +17,10 @@ const Cart = () => {
 
   useEffect(() => {
     handleTotal();
-  }, []);
+  }, [cart]);
   useEffect(() => {
     calculateTax();
-  }, [subTotal]);
+  }, [subTotal, cart]);
 
   const handleCheckout = () => {
     navigate("/checkout", { state: { cart, subTotal, taxAmount } });


### PR DESCRIPTION
This PR fixes the sub total and total in cart if an item is removed. Now it's in sync. Fix of [issue](https://github.com/KriteshTimsina/sastobazaar-ecommerce/issues/14)